### PR TITLE
Convenience constructors should be prefixed with the type name, not init

### DIFF
--- a/SESpringBoardDemo/SESpringBoard/SEMenuItem.h
+++ b/SESpringBoardDemo/SESpringBoard/SEMenuItem.h
@@ -22,7 +22,9 @@
 @property BOOL isInEditingMode;
 @property (nonatomic, assign) id <MenuItemDelegate> delegate;
 
-+ (id) initWithTitle:(NSString *)title imageName:(NSString *)imageName viewController:(UIViewController *)viewController removable:(BOOL)removable;
+- (id) initWithTitle:(NSString *)title :(NSString *)imageName :(UIViewController *)viewController :(BOOL)removable;
+
++ (id) menuItemWithTitle:(NSString *)title imageName:(NSString *)imageName viewController:(UIViewController *)viewController removable:(BOOL)removable;
 
 - (void) enableEditing;
 - (void) disableEditing;

--- a/SESpringBoardDemo/SESpringBoard/SEMenuItem.m
+++ b/SESpringBoardDemo/SESpringBoard/SEMenuItem.m
@@ -91,7 +91,7 @@
     return self;
 }
 
-+ (id) initWithTitle:(NSString *)title imageName:(NSString *)imageName viewController:(UIViewController *)viewController removable:(BOOL)removable  {
++ (id) menuItemWithTitle:(NSString *)title imageName:(NSString *)imageName viewController:(UIViewController *)viewController removable:(BOOL)removable {
 	SEMenuItem *tmpInstance = [[[SEMenuItem alloc] initWithTitle:title :imageName :viewController :removable] autorelease];
 	return tmpInstance;
 }


### PR DESCRIPTION
A value returned from a method prefixed with init is assumed to be owned by the caller, not unowned and autoreleased. This will cause errors when you convert to ARC.
